### PR TITLE
fix: drop None

### DIFF
--- a/HubitatIntegration.py
+++ b/HubitatIntegration.py
@@ -102,11 +102,11 @@ class HubitatIntegration(MycroftSkill):
             try:
                 device = self.get_hub_device_name(message)
             except:
-                # g_h_d_n speaks a dialog before throwing anerror
+                # g_h_d_n speaks a dialog before throwing an error
                 return
 
             level = message.data.get('level')
-            supported_modes = [s.strip() for s in self.hub_get_attribute(self.hub_get_device_id(device), "supportedThermostatModes").strip('[]').split(',')]
+            supported_modes = [s.strip() for s in self.hub_get_attribute(self.hub_get_device_id(device), "supportedThermostatModes").strip('[]').split(',') if isinstance(s, str)]
             self.log.debug("Set Level Supported Modes: " + str(supported_modes))
             self.log.debug("Level is: " + str(level))
 

--- a/HubitatIntegration.py
+++ b/HubitatIntegration.py
@@ -206,7 +206,7 @@ class HubitatIntegration(MycroftSkill):
         utt_device = message.data.get('device')
         self.log.debug(utt_device)
         if utt_device is None:
-            raise NameError('NoDevice')
+            self.log.error('No Device passed in utterance!')
         device_name = self.get_hub_device_name_from_text(utt_device)
         self.log.debug("Device is " + str(device_name))
         return device_name
@@ -238,7 +238,7 @@ class HubitatIntegration(MycroftSkill):
         # Nothing had a high enough score.  Speak and throw.
         self.log.debug("No device found for " + text)
         self.speak_dialog('device.not.supported', data={'device': text})
-        raise Exception("Unsupported Device")
+        self.log.error("Unsupported Device")
 
     def hub_get_device_id(self, device):
         # devIds is a dict with the device name from hubitat as the key, and the ID number as the value.
@@ -272,7 +272,7 @@ class HubitatIntegration(MycroftSkill):
         else:
             self.log.debug("No device found for " + name)
             self.speak_dialog('attr.not.supported', data={'device': 'any device in settings', 'attr': name})
-            raise Exception("Unsupported Attribute")
+            self.log.error(f"Unsupported Attribute for {name}")
 
     def hub_command_devices(self, dev_id, state, value=None):
         # Build a URL to send the requested command to the Hubitat and

--- a/HubitatIntegration.py
+++ b/HubitatIntegration.py
@@ -309,9 +309,9 @@ class HubitatIntegration(MycroftSkill):
             if info == "attributes":
                 for ret_attr in jsn[info]:
                     if ret_attr['name'] == attr:
-                        self.log.debug("Found Attribute Match: " + str(ret_attr['currentValue']))
-                        return ret_attr['currentValue']
-        return None
+                        self.log.debug("Found Attribute Match: " + str(ret_attr.get('currentValue')))
+                        return ret_attr.get('currentValue')
+        return ""
     
     def update_devices(self):
         json_data = None


### PR DESCRIPTION
This list comprehension is throwing errors, per Matrix chat, because there are attempted string methods on Nonetype objects. This adds a conditional to stop that, as well as using Dict.get() to return a default empty string.

Could fix #6 